### PR TITLE
Added checks for ens&did sync interval env variables

### DIFF
--- a/src/ENS/ens.service.ts
+++ b/src/ENS/ens.service.ts
@@ -60,10 +60,11 @@ export class EnsService {
     );
 
     // Using setInterval so that interval can be set dynamically from config
-    const interval = setInterval(
-      () => this.syncENS(),
-      parseInt(this.config.get<string>('ENS_SYNC_INTERVAL_IN_MS')));
-    this.schedulerRegistry.addInterval('ENS Sync', interval);
+    const ensSyncInterval = this.config.get<string>('ENS_SYNC_INTERVAL_IN_MS');
+    if (ensSyncInterval) {
+      const interval = setInterval(() => this.syncENS(), parseInt(ensSyncInterval));
+      this.schedulerRegistry.addInterval('ENS Sync', interval);
+    }
 
     this.InitEventListeners();
     this.loadNamespaces();

--- a/src/did/did.service.ts
+++ b/src/did/did.service.ts
@@ -53,10 +53,11 @@ export class DIDService {
     this.InitEventListeners();
 
     // Using setInterval so that interval can be set dynamically from config
-    const interval = setInterval(
-      () => this.syncDocuments(),
-      parseInt(this.config.get<string>('DIDDOC_SYNC_INTERVAL_IN_MS')));
-    this.schedulerRegistry.addInterval('DID Document Sync', interval);
+    const didDocSyncInteral = this.config.get<string>('DIDDOC_SYNC_INTERVAL_IN_MS');
+    if (didDocSyncInteral) {
+      const interval = setInterval(() => this.syncDocuments(), parseInt(didDocSyncInteral));
+      this.schedulerRegistry.addInterval('DID Document Sync', interval);
+    }
   }
 
   private async InitEventListeners(): Promise<void> {
@@ -75,6 +76,7 @@ export class DIDService {
   }
 
   private async syncDocuments() {
+    this.logger.log(`Beginning sync of DID Documents`)
     const cachedDIDs = await this.didRepository.queryAllDIDs();
     cachedDIDs.forEach(async (did) => {
       await this.didQueue.add(this.refresh_queue_channel, did.id);


### PR DESCRIPTION
If the sync interval env variables weren't provided then sync interval was very short, leading to an overwhelming sync frequency. This adds checks so that the sync doesn't occur if the interval variables aren't provided.