### PR TITLE
Correcting nested type filters in App and Org

### DIFF
--- a/src/application/application.service.ts
+++ b/src/application/application.service.ts
@@ -35,9 +35,9 @@ export class ApplicationService {
     const res = await this.dgraph.query(
       `
     query all($i: string){
-      Data(func: eq(namespace, $i)) @filter(eq(dgraph.type, "Role")) {
+      Data(func: eq(namespace, $i)) @filter(eq(dgraph.type, "App")) {
         namespace
-        roles {
+        roles @filter(eq(dgraph.type, "Role")) {
           ${baseQueryFields}
         }
       }

--- a/src/organization/organization.service.ts
+++ b/src/organization/organization.service.ts
@@ -30,9 +30,9 @@ export class OrganizationService {
     const res = await this.dgraph.query(
       `
     query all($i: string){
-      Data(func: eq(namespace, $i)) @filter(eq(dgraph.type, "App")) {
+      Data(func: eq(namespace, $i)) @filter(eq(dgraph.type, "Org")) {
         namespace
-        apps {
+        apps @filter(eq(dgraph.type, "App")) {
           name
           namespace
           owner
@@ -50,9 +50,9 @@ export class OrganizationService {
     const res = await this.dgraph.query(
       `
     query all($i: string){
-      Data(func: eq(namespace, $i)) @filter(eq(dgraph.type, "Role")) {
+      Data(func: eq(namespace, $i)) @filter(eq(dgraph.type, "Org")) {
         namespace
-        roles {
+        roles @filter(eq(dgraph.type, "Role")) {
           name
           namespace
           owner


### PR DESCRIPTION
Correcting nested filters in App and Org. Looked through the rest of application, these seem to be the only three spots.

Note, probably need to add type filter to the search queries (in `NamespaceService` as well to prevent duplicates if not done so already. Can do that in separate PR.