### PR TITLE
Fixing parsing of "includeClaims" param in Did GET

### DIFF
--- a/src/did/did.controller.ts
+++ b/src/did/did.controller.ts
@@ -28,11 +28,12 @@ export class DIDController {
   @UseInterceptors(NotFoundInterceptor)
   public async getById(
     @Param('did') id: string,
-    @Query('includeClaims') includeClaims: boolean
+    @Query('includeClaims') includeClaimsString: string
   ) {
     try {
-      this.logger.log(`Retrieving document for did: ${id} with includeClaims: ${includeClaims}`)
+      this.logger.log(`Retrieving document for did: ${id} with includeClaims: ${includeClaimsString}`)
       const did = new DID(id);
+      const includeClaims = (includeClaimsString === 'true');
       const didDocument = await this.didService.getById(did, includeClaims);
 
       // If DID document isn't in the cache, queue cache so that it can be retrieved on subsequent calls 


### PR DESCRIPTION
"includeClaims" param wasn't being parsed as boolean and so I'm doing so manually now. @marcin-l-tsh @dwojno is there a better way to do this? I tried using the nest `ParseBoolPipe` but it requires the param to be mandatory.

Expected behaviour of "includeClaims" param:
- if "includeClaims" is "true" then add claim Data
- else don't add claim data