### PR TITLE
fix(docker-compose.dev): remove backticks

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,4 @@
-```version: '3.4'
+version: '3.4'
 
 services:
   app:
@@ -60,4 +60,4 @@ networks:
 
 volumes:
   dgraph:
-```
+


### PR DESCRIPTION
Must have been a typo. Not sure why they would be there at all