### PR TITLE
Task/ics 223 fix ens sync

### DIFF
--- a/docs/api/classes/modules_role_role_dto.RevokerDTO.md
+++ b/docs/api/classes/modules_role_role_dto.RevokerDTO.md
@@ -62,13 +62,13 @@ IRevokerDefinition.roleName
 
 ### create
 
-▸ `Static` **create**(`data`): `Promise`<[`RevokerDTO`](modules_role_role_dto.RevokerDTO.md)\>
+▸ `Static` **create**(`data?`): `Promise`<[`RevokerDTO`](modules_role_role_dto.RevokerDTO.md)\>
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `data` | `Partial`<[`RevokerDTO`](modules_role_role_dto.RevokerDTO.md)\> |
+| `data?` | `Partial`<[`RevokerDTO`](modules_role_role_dto.RevokerDTO.md)\> |
 
 #### Returns
 

--- a/src/modules/role/role.dto.ts
+++ b/src/modules/role/role.dto.ts
@@ -111,8 +111,16 @@ export class IssuerDTO implements Issuer {
 }
 
 export class RevokerDTO implements IRevokerDefinition {
-  static async create(data: Partial<RevokerDTO>) {
+  static async create(data?: Partial<RevokerDTO>) {
     const dto = new RevokerDTO();
+    if (!data) {
+      Object.assign(dto, {
+        revokerType: 'DID',
+        did: [],
+      });
+      return dto;
+    }
+
     Object.assign(dto, data);
     await validateOrReject(dto, { whitelist: true });
     return dto;

--- a/src/modules/status-list/entities/status-list-credential.entity.ts
+++ b/src/modules/status-list/entities/status-list-credential.entity.ts
@@ -38,7 +38,8 @@ export class StatusListCredential {
         statusPurpose: 'revocation',
         encodedList,
       },
-      issuer: new DID(issuerDid).withHexChain(),
+      // toLowerCase used because DIDKit proof verification requires lowercase
+      issuer: new DID(issuerDid).withHexChain().toLowerCase(),
       issuanceDate: new Date().toISOString(),
     };
 

--- a/src/modules/status-list/status-list.service.spec.ts
+++ b/src/modules/status-list/status-list.service.spec.ts
@@ -212,7 +212,8 @@ describe('StatusList2021 service', () => {
         ],
         id: credential.credentialStatus.statusListCredential,
         type: ['VerifiableCredential', 'StatusList2021Credential'],
-        issuer: 'did:ethr:0x12047:0xe852f6784EeD893cC81dDa21D31f212332CC120a',
+        issuer:
+          'did:ethr:0x12047:0xe852f6784EeD893cC81dDa21D31f212332CC120a'.toLowerCase(),
         issuanceDate: expect.any(String),
         credentialSubject: {
           id: credential.credentialStatus.statusListCredential,

--- a/test/status-list/status-list.testSuite.ts
+++ b/test/status-list/status-list.testSuite.ts
@@ -355,7 +355,7 @@ export const statusList2021TestSuite = () => {
         ],
         id: vc.credentialStatus.statusListCredential,
         type: ['VerifiableCredential', 'StatusList2021Credential'],
-        issuer: issuer.didHex,
+        issuer: issuer.didHex.toLowerCase(),
         issuanceDate: expect.any(String),
         credentialSubject: {
           id: vc.credentialStatus.statusListCredential,


### PR DESCRIPTION
Fix ens sync when role has no revoker property (RoleDefinition v1).
Refactor role ens sync.
Sort domain list before sync (I noticed much less errors).
Fix for status list: issuer in lowercase, expected from didkit library to verify VC correctly.