### PR TITLE
fix: updating roles definition

### DIFF
--- a/src/modules/role/role.service.ts
+++ b/src/modules/role/role.service.ts
@@ -147,7 +147,6 @@ export class RoleService {
         ...role,
         ...data,
         parentApp: app,
-        definition: { ...role.definition },
       });
       return this.roleRepository.save(updatedRole);
     }
@@ -160,7 +159,6 @@ export class RoleService {
         ...role,
         ...data,
         parentOrg: org,
-        definition: { ...role.definition },
       });
       return this.roleRepository.save(updatedRole);
     }


### PR DESCRIPTION
`role` is the previous object in database and `data` is the new definition. It always save old definition during update.