### PR TITLE
Revert "chore: update memory and cpu limits"

### DIFF
--- a/devops/dev/values.yaml
+++ b/devops/dev/values.yaml
@@ -126,20 +126,24 @@ iam-cache-server-helm:
     DB_MAXIMUM_CONNECTION_POOL: 56 # https://github.com/energywebfoundation/iam-cache-server/blob/develop/README.md#connection-pooling
     SENTRY_ENV: dev
 
-  resources:
-    limits:
-      cpu: 750m
-      memory: 768Mi # spike of memory on initilaization of didkit-wasm-node requires higher limit https://github.com/spruceid/didkit/issues/301
-    requests:
-      cpu: 500m
-      memory: 256Mi
+  resources: { }
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
 
   autoscaling:
-    enabled: true
-    minReplicas: 2
-    maxReplicas: 4
-    targetCPUUtilizationPercentage: 60
-    targetMemoryUtilizationPercentage: 85
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 1
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
 
   nodeSelector: { }
 

--- a/devops/prod/values.yaml
+++ b/devops/prod/values.yaml
@@ -131,7 +131,7 @@ iam-cache-server-helm:
   resources:
     limits:
       cpu: 750m
-      memory: 768Mi # spike of memory on initilaization of didkit-wasm-node requires higher limit https://github.com/spruceid/didkit/issues/301
+      memory: 384Mi
     requests:
       cpu: 500m
       memory: 256Mi
@@ -140,7 +140,7 @@ iam-cache-server-helm:
     enabled: true
     minReplicas: 3
     maxReplicas: 6
-    targetCPUUtilizationPercentage: 60
+    targetCPUUtilizationPercentage: 50
     targetMemoryUtilizationPercentage: 85
 
   nodeSelector: { }

--- a/devops/staging/values.yaml
+++ b/devops/staging/values.yaml
@@ -133,17 +133,17 @@ iam-cache-server-helm:
 
   resources:
     limits:
-      cpu: 750m
-      memory: 768Mi # spike of memory on initilaization of didkit-wasm-node requires higher limit https://github.com/spruceid/didkit/issues/301
-    requests:
       cpu: 500m
+      memory: 384Mi
+    requests:
+      cpu: 250m
       memory: 256Mi
 
   autoscaling:
     enabled: true
     minReplicas: 2
     maxReplicas: 4
-    targetCPUUtilizationPercentage: 60
+    targetCPUUtilizationPercentage: 50
     targetMemoryUtilizationPercentage: 85
 
   nodeSelector: { }


### PR DESCRIPTION
Reverts energywebfoundation/ssi-hub#444

These limits aren't sufficient to avoid the pod startup issues