### PR TITLE
fix: send asset id as did to DID pipe

### DIFF
--- a/src/modules/assets/assets.controller.ts
+++ b/src/modules/assets/assets.controller.ts
@@ -66,7 +66,7 @@ export class AssetsController {
     enum: AssetHistoryEventType,
   })
   async getHistoryByAssetId(
-    @Param('id', DIDPipe) { id }: DID,
+    @Param('id', DIDPipe) { did: id }: DID,
     @Query('take', new DefaultValuePipe(10), ParseIntPipe) take?: number,
     @Query('skip', new DefaultValuePipe(0), ParseIntPipe) skip?: number,
     @Query('order') order?: Order,

--- a/src/modules/assets/assets.service.ts
+++ b/src/modules/assets/assets.service.ts
@@ -183,8 +183,8 @@ export class AssetsService {
       async (identity: string, owner: string, at: BigNumber) => {
         const atAsNumber = at.toNumber();
         const assetDto = await AssetDto.create({
-          id: getDIDFromAddress(identity),
-          owner: getDIDFromAddress(owner),
+          id: new DID(identity).did,
+          owner: new DID(owner).did,
           at: atAsNumber,
         });
 


### PR DESCRIPTION
- The DID pipe was sending ID and stripping away the chain info ('did'ethr...'). 
- (0xEa242C31FCcB83Aa1Bf3b29e4B4b276E85024aa8 from did:ethr:volta:0xEa242C31FCcB83Aa1Bf3b29e4B4b276E85024aa8)
- Asset IDs are saved in the database in this format, so it wasn't finding any records. 

ASSET_TRANSFERRED event for did:ethr:volta:0x921*** saved: {\**"assetId\":\"did:ethr:volta:0x921*****\",\"at\":PHONE_NUMBER,\"emittedBy\":\"did:ethr:volta:0x06B***\",\"timestamp\":\"DIGITS-08-19T13:37:50.000Z\",\"relatedTo\":\"did:ethr:volta:0x17b***\",\"type\":\"ASSET_TRANSFERRED\",\"id\":DIGITS}\n"