### PR TITLE
fix: convert addresses to DIDs before inserting to DB

### DIFF
--- a/src/modules/assets/assets.service.ts
+++ b/src/modules/assets/assets.service.ts
@@ -183,8 +183,8 @@ export class AssetsService {
       async (identity: string, owner: string, at: BigNumber) => {
         const atAsNumber = at.toNumber();
         const assetDto = await AssetDto.create({
-          id: new DID(identity).did,
-          owner: new DID(owner).did,
+          id: getDIDFromAddress(identity),
+          owner: getDIDFromAddress(owner),
           at: atAsNumber,
         });
 


### PR DESCRIPTION
- For bug https://energyweb.atlassian.net/browse/SWTCH-1424 
- Converts addresses to DIDs before inserting into Asset DB
- Addresses the following error thrown in SSI hub:

2022-08-29 07:47:07 | {"log":"This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason:\n","stream":"stderr","time":"2022-08-29T11:47:07.573531931Z"}
-- | --
| 2022-08-29 07:47:06 | {"log":"    at processTimers (node:internal/timers:500:7)\n","stream":"stderr","time":"2022-08-29T11:47:06.007813164Z"}
 | 2022-08-29 07:47:06 | {"log":"    at listOnTimeout (node:internal/timers:557:17)\n","stream":"stderr","time":"2022-08-29T11:47:06.007810093Z"}
 | 2022-08-29 07:47:06 | {"log":"    at Timeout._onTimeout (/app/node_modules/@ethersproject/contracts/lib/index.js:502:31)\n","stream":"stderr","time":"2022-08-29T11:47:06.007798629Z"}
| 2022-08-29 07:47:06 | {"log":"    at FragmentRunningEvent.\u003canonymous\u003e (/app/dist/modules/assets/assets.service.js:140:21)\n","stream":"stderr","time":"2022-08-29T11:47:06.007795038Z"}
| 2022-08-29 07:47:06 | {"log":"    at new DID (/app/dist/modules/did/did.types.js:13:19)\n","stream":"stderr","time":"2022-08-29T11:47:06.007791859Z"}
 | 2022-08-29 07:47:06 | {"log":"Error: Malformed did 0xDd8e4A7B7a666d434d1FA6609f06B48c47190d0A\n","stream":"stderr","time":"2022-08-29T11:47:06.007787761Z"}

