### PR TITLE
fix: log revoker error for debugging

### DIFF
--- a/docs/api/classes/modules_status_list_status_list_service.StatusListService.md
+++ b/docs/api/classes/modules_status_list_status_list_service.StatusListService.md
@@ -24,7 +24,7 @@
 
 ### constructor
 
-• **new StatusListService**(`configService`, `credentialWithStatusRepository`, `namespaceStatusListsRepository`, `namespaceStatusListRepository`, `statusListCredentialRepository`, `revocationVerificationService`)
+• **new StatusListService**(`configService`, `credentialWithStatusRepository`, `namespaceStatusListsRepository`, `namespaceStatusListRepository`, `statusListCredentialRepository`, `revocationVerificationService`, `logger`)
 
 #### Parameters
 
@@ -36,6 +36,7 @@
 | `namespaceStatusListRepository` | `Repository`<[`NamespaceStatusList`](modules_status_list_entities_namespace_status_list_entity.NamespaceStatusList.md)\> |
 | `statusListCredentialRepository` | `Repository`<[`StatusListCredential`](modules_status_list_entities_status_list_credential_entity.StatusListCredential.md)\> |
 | `revocationVerificationService` | [`RevocationVerificationService`](modules_claim_services_revocation_verification_service.RevocationVerificationService.md) |
+| `logger` | [`Logger`](modules_logger_logger_service.Logger.md) |
 
 ## Methods
 

--- a/src/modules/status-list/status-list.service.spec.ts
+++ b/src/modules/status-list/status-list.service.spec.ts
@@ -12,6 +12,7 @@ import {
 } from './entities';
 import { CredentialType } from '@ew-did-registry/credentials-interface';
 import { RevocationVerificationService } from '../claim/services';
+import { Logger } from '../logger/logger.service';
 
 describe('StatusList2021 service', () => {
   let service: StatusListService;
@@ -43,6 +44,14 @@ describe('StatusList2021 service', () => {
     save: jest.fn(),
   };
 
+  const mockLogger = {
+    log: jest.fn(),
+    error: jest.fn(),
+    setContext: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  };
+
   beforeEach(async () => {
     jest.resetAllMocks();
 
@@ -52,7 +61,8 @@ describe('StatusList2021 service', () => {
       namespaceStatusListsRepository as unknown as Repository<NamespaceStatusLists>,
       namespaceStatusListRepository as unknown as Repository<NamespaceStatusList>,
       statusListCredentialRepository as unknown as Repository<StatusListCredential>,
-      {} as unknown as RevocationVerificationService
+      {} as unknown as RevocationVerificationService,
+      mockLogger as unknown as Logger
     );
   });
 

--- a/src/modules/status-list/status-list.service.ts
+++ b/src/modules/status-list/status-list.service.ts
@@ -21,6 +21,7 @@ import {
   NamespaceStatusList,
 } from './entities';
 import { RevocationVerificationService } from '../claim/services';
+import { Logger } from '../logger/logger.service';
 
 @Injectable()
 export class StatusListService {
@@ -34,8 +35,11 @@ export class StatusListService {
     private readonly namespaceStatusListRepository: Repository<NamespaceStatusList>,
     @InjectRepository(StatusListCredential)
     private readonly statusListCredentialRepository: Repository<StatusListCredential>,
-    private readonly revocationVerificationService: RevocationVerificationService
-  ) {}
+    private readonly revocationVerificationService: RevocationVerificationService,
+    private readonly logger: Logger
+  ) {
+    this.logger.setContext(StatusListService.name);
+  }
 
   /**
    * Add StatusList2021Entry as `credentialStatus` parameter to given credential object.
@@ -277,7 +281,8 @@ export class StatusListService {
   async verifyRevoker(user: string, namespace: string) {
     try {
       await this.revocationVerificationService.verifyRevoker(user, namespace);
-    } catch {
+    } catch (e) {
+      this.logger.error(`Revoker verification failed with error ${e}`);
       throw new ForbiddenException(
         `${user} is not allowed to revoke ${namespace}`
       );

--- a/src/modules/status-list/status-list.service.ts
+++ b/src/modules/status-list/status-list.service.ts
@@ -282,7 +282,7 @@ export class StatusListService {
     try {
       await this.revocationVerificationService.verifyRevoker(user, namespace);
     } catch (e) {
-      this.logger.error(`Revoker verification failed with error ${e}`);
+      this.logger.error(`Revoker verification failed with error: ${e}`);
       throw new ForbiddenException(
         `${user} is not allowed to revoke ${namespace}`
       );


### PR DESCRIPTION
- verifyRevoker in ew-credentials throws several different errors. SSI Hub does not handle the reason at all, so there is no way of knowing why the verifyRevoker failed. This adds a catch so the logger can log the error description. I would add that we should add the reason to the throw message as well, but that is up for debate. At the very least, we can log the error. 