### PR TITLE
remove hardhat config from dist

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,5 +5,5 @@
     "inlineSources": true,
     "sourceRoot": "/"
   },
-  "exclude": ["node_modules", "e2e", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "e2e", "dist", "**/*spec.ts", "hardhat.config.ts"]
 }


### PR DESCRIPTION
Having hardhat config in dist forces typescript include src/ directory in dist, which leads to inability to resolve main.js, which is expected to be in root of dist