### PR TITLE
#swtch 1539 revoke by role

### DIFF
--- a/src/modules/claim/resolvers/credential.resolver.ts
+++ b/src/modules/claim/resolvers/credential.resolver.ts
@@ -76,7 +76,11 @@ export class RoleCredentialResolver implements CredentialResolver {
     return tokens
       .map((token) => {
         try {
-          return jwt.decode(token) as RolePayload;
+          const decoded = jwt.decode(token) as RolePayload;
+          return {
+            eip191Jwt: token,
+            payload: decoded,
+          };
         } catch (_) {
           return {};
         }

--- a/src/modules/did/did.service.ts
+++ b/src/modules/did/did.service.ts
@@ -331,8 +331,12 @@ export class DIDService implements OnModuleInit, OnModuleDestroy {
     return Promise.all(
       service
         .map(({ serviceEndpoint }) => serviceEndpoint)
-        .filter(IPFSService.isCID)
-        .map(this.didStore.get)
+        .filter((endpoint) => {
+          return IPFSService.isCID(endpoint);
+        })
+        .map((did) => {
+          return this.didStore.get(did);
+        })
     );
   }
 

--- a/src/modules/did/did.service.ts
+++ b/src/modules/did/did.service.ts
@@ -331,12 +331,8 @@ export class DIDService implements OnModuleInit, OnModuleDestroy {
     return Promise.all(
       service
         .map(({ serviceEndpoint }) => serviceEndpoint)
-        .filter((endpoint) => {
-          return IPFSService.isCID(endpoint);
-        })
-        .map((did) => {
-          return this.didStore.get(did);
-        })
+        .filter((endpoint) => IPFSService.isCID(endpoint))
+        .map((cid) => this.didStore.get(cid))
     );
   }
 


### PR DESCRIPTION
Fix for bug https://energyweb.atlassian.net/jira/software/projects/SWTCH/boards/54?assignee=608057a2e3b59800688dbc2a&selectedIssue=SWTCH-1539

Fixes 2 issues:
1. Uses arrow in chained methods in order to preserve "this" context (fixes issue of cannot read 'ipfs' of undefined or this)
2. Formats token so it can be passed to isEIP191Jwt method. Previously was not formatted and so no claims were coming back from the check, and therefore the pre-requisite role was never found for verifier

Regression testing performed:
1. Can revoke on-chain credential for role-based revoker
2. Can revoke off-chain credential for did-based revoker
3. Can revoke on-chain credential for did-based revoker

**I'm thinking we won't want to merge this till after demo tomorrow, just in case, even if approved**