### PR TITLE
feat: configuration validation

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -10,7 +10,7 @@ DB_NAME=dev-test
 
 # Redis
 REDIS_VERSION=6.0.8
-REDIS_PASSWORD=password
+#REDIS_PASSWORD=password
 REDIS_PORT=6379
 REDIS_HOST=redis
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -97,11 +97,13 @@ jobs:
           CHAIN_NAME: volta
           PUBLIC_RESOLVER_ADDRESS: ${{secrets.PUBLIC_RESOLVER_ADDRESS}}
           RESOLVER_V1_ADDRESS: ${{secrets.RESOLVER_V1_ADDRESS}}
+          RESOLVER_V2_ADDRESS: '0xcf72f16Ab886776232bea2fcf3689761a0b74EfE'
           DOMAIN_NOTIFIER_ADDRESS: ${{secrets.DOMAIN_NOTIFIER_ADDRESS}}
           ENS_SYNC_INTERVAL_IN_HOURS: ${{secrets.ENS_SYNC_INTERVAL_IN_HOURS}}
           ENS_URL: ${{secrets.ENS_URL}}
           REDIS_HOST: ${{secrets.REDIS_HOST}}
           REDIS_PORT: ${{ job.services.redis.ports[6379] }}
+          REDIS_PASSWORD: foobar
           NATS_CLIENTS_URL: ${{secrets.NATS_CLIENTS_URL}}
           JWT_PUBLIC_KEY: ${{secrets.JWT_PUBLIC_KEY}}
           JWT_PRIVATE_KEY: ${{secrets.JWT_PRIVATE_KEY}}
@@ -115,7 +117,10 @@ jobs:
           JWT_ACCESS_TOKEN_NAME: ${{secrets.JWT_ACCESS_TOKEN_NAME}}
           JWT_REFRESH_TOKEN_NAME: ${{secrets.JWT_REFRESH_TOKEN_NAME}}
           UNIVERSAL_RESOLVER_URL: ${{secrets.UNIVERSAL_RESOLVER_URL}}
+          ROOT_DOMAIN: iam.ewc
           ENS_SYNC_ENABLED: ${{secrets.ENS_SYNC_ENABLED}}
+          DID_SYNC_ENABLED: false
+          DIDDOC_SYNC_INTERVAL_IN_HOURS: 21
           DID_REGISTRY_ADDRESS: ${{secrets.DID_REGISTRY_ADDRESS}}
           CLAIM_MANAGER_ADDRESS: ${{secrets.CLAIM_MANAGER_ADDRESS}}
           ASSETS_MANAGER_ADDRESS: ${{secrets.ASSETS_MANAGER_ADDRESS}}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -48,7 +48,6 @@ services:
   redis:
     container_name: redis
     image: redis:${REDIS_VERSION}
-    command: redis-server --requirepass ${REDIS_PASSWORD}
     volumes:
       - $PWD/redis-data:/var/lib/redis
     environment:

--- a/docs/api/modules.md
+++ b/docs/api/modules.md
@@ -16,6 +16,7 @@
 - [common/user.decorator](modules/common_user_decorator.md)
 - [db/cli](modules/db_cli.md)
 - [db/config](modules/db_config.md)
+- [env-vars-validation-schema](modules/env_vars_validation_schema.md)
 - [errors/MalformedDIDErrro](modules/errors_MalformedDIDErrro.md)
 - [graphql/config](modules/graphql_config.md)
 - [graphql/graphql.parser](modules/graphql_graphql_parser.md)

--- a/docs/api/modules/env_vars_validation_schema.md
+++ b/docs/api/modules/env_vars_validation_schema.md
@@ -1,0 +1,13 @@
+# Module: env-vars-validation-schema
+
+## Table of contents
+
+### Variables
+
+- [envVarsValidationSchema](env_vars_validation_schema.md#envvarsvalidationschema)
+
+## Variables
+
+### envVarsValidationSchema
+
+• `Const` **envVarsValidationSchema**: `ObjectSchema`<`any`\>

--- a/e2e/app.e2e.spec.ts
+++ b/e2e/app.e2e.spec.ts
@@ -18,7 +18,7 @@ import { ConfigService } from '@nestjs/config';
 
 export let app: INestApplication;
 
-jest.setTimeout(20000000);
+jest.setTimeout(600_000);
 describe('iam-cache-server E2E tests', () => {
   const provider = ethers.provider;
   const deployer = provider.getSigner(0);

--- a/e2e/app.e2e.spec.ts
+++ b/e2e/app.e2e.spec.ts
@@ -14,6 +14,7 @@ import { EthereumDIDRegistry } from '../src/ethers/EthereumDIDRegistry';
 import { EthereumDIDRegistry__factory } from '../src/ethers/factories/EthereumDIDRegistry__factory';
 import { didModuleTestSuite } from './did/did-service';
 import { Provider } from '../src/common/provider';
+import { ConfigService } from '@nestjs/config';
 
 export let app: INestApplication;
 
@@ -37,6 +38,7 @@ describe('iam-cache-server E2E tests', () => {
 
     didRegistry = await loadFixture(deployDidRegistry);
     process.env.DID_REGISTRY_ADDRESS = didRegistry.address;
+    const configService = new ConfigService(); // this is necessary to have values updated in the ConfigService provider
 
     const testingModule = await Test.createTestingModule({
       imports: [AppModule],
@@ -45,6 +47,8 @@ describe('iam-cache-server E2E tests', () => {
       .useValue(await spawnIpfsDaemon())
       .overrideProvider(Provider)
       .useValue(provider)
+      .overrideProvider(ConfigService)
+      .useValue(configService)
       .compile();
     app = testingModule.createNestApplication();
     appConfig(app);

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -28,7 +28,7 @@ import { DIDContactModule } from './modules/did-contact/did.contact.module';
 import { StatusListModule } from './modules/status-list/status-list.module';
 import { IPFSModule } from './modules/ipfs/ipfs.module';
 import { ValidationOptions } from 'joi';
-import { envVarsValidationSchema } from './env-vars-validation-schema';
+import { envVarsValidationSchema as validationSchema } from './env-vars-validation-schema';
 
 const validationOptions: ValidationOptions = {
   stripUnknown: true,
@@ -42,7 +42,7 @@ try {
   config = ConfigModule.forRoot({
     isGlobal: true,
     validationOptions,
-    validationSchema: envVarsValidationSchema,
+    validationSchema,
   });
 } catch (err) {
   console.log(err.toString());

--- a/src/env-vars-validation-schema.ts
+++ b/src/env-vars-validation-schema.ts
@@ -1,0 +1,92 @@
+import JoiBase, { CustomHelpers } from 'joi';
+import { utils } from 'ethers';
+
+declare type JoiType = typeof JoiBase;
+
+interface ExtendedJoi extends JoiType {
+  ethAddr(): this;
+}
+
+const Joi = <ExtendedJoi>JoiBase.extend((joi) => ({
+  type: 'ethAddr',
+  base: joi.string(),
+  messages: {
+    ethAddr: '{{#label}} must be a valid ethereum address',
+  },
+  validate(value: string, helpers: CustomHelpers) {
+    if (!utils.isAddress(value)) {
+      return { value, errors: helpers.error('ethAddr') };
+    }
+
+    return { value };
+  },
+}));
+
+export const envVarsValidationSchema = Joi.object({
+  NODE_ENV: Joi.string()
+    .valid('development', 'production', 'test')
+    .default('development'),
+
+  NESTJS_PORT: Joi.number().port().default(3000),
+
+  DB_HOST: Joi.string().hostname().required(),
+  DB_PORT: Joi.number().port().required(),
+  DB_NAME: Joi.string().required(),
+  DB_USERNAME: Joi.string().required(),
+  DB_PASSWORD: Joi.string().required(),
+
+  REDIS_PASSWORD: Joi.string().required(),
+  REDIS_PORT: Joi.number().port().required(),
+  REDIS_HOST: Joi.string().hostname().required(),
+
+  NATS_CLIENTS_URL: Joi.string().required(), // TODO: store whole URL here, including `nats://` and validate as URL
+  NATS_ENVIRONMENT_NAME: Joi.string().required(),
+
+  ROOT_DOMAIN: Joi.string().domain().required(),
+  CHAIN_ID: Joi.number().positive().required(),
+  CHAIN_NAME: Joi.string().required(),
+  ENS_URL: Joi.string().uri().required(),
+
+  PUBLIC_RESOLVER_ADDRESS: Joi.ethAddr().required(),
+  ENS_REGISTRY_ADDRESS: Joi.ethAddr().required(),
+  DID_REGISTRY_ADDRESS: Joi.ethAddr().required(),
+  DOMAIN_NOTIFIER_ADDRESS: Joi.ethAddr().required(),
+  RESOLVER_V1_ADDRESS: Joi.ethAddr().required(),
+  RESOLVER_V2_ADDRESS: Joi.ethAddr().required(),
+  CHAIN_REQUEST_ATTEMPTS: Joi.number().positive(),
+
+  ASSETS_MANAGER_ADDRESS: Joi.ethAddr().required(),
+  ASSETS_SYNC_INTERVAL_IN_HOURS: Joi.number().positive().required(),
+  ASSETS_SYNC_HISTORY_INTERVAL_IN_HOURS: Joi.number().positive().required(),
+  ASSETS_SYNC_ENABLED: Joi.boolean().required(),
+
+  IPFS_CLIENT_HOST: Joi.string().hostname(),
+  IPFS_CLIENT_PORT: Joi.number().port(),
+  IPFS_CLIENT_PROJECT_ID: Joi.string(),
+  IPFS_CLIENT_PROJECT_SECRET: Joi.string(),
+
+  DID_SYNC_MODE_FULL: Joi.boolean().required(),
+  DID_SYNC_ENABLED: Joi.boolean().required(),
+  DIDDOC_SYNC_INTERVAL_IN_HOURS: Joi.number().positive().required(),
+  ENS_SYNC_ENABLED: Joi.boolean().required(),
+  ENS_SYNC_INTERVAL_IN_HOURS: Joi.number().positive().required(),
+
+  ENABLE_AUTH: Joi.boolean().required(),
+  JWT_PRIVATE_KEY: Joi.string().required(),
+  JWT_PUBLIC_KEY: Joi.string().required(),
+  STRATEGY_CACHE_SERVER: Joi.string().uri().required(),
+  STRATEGY_PRIVATE_KEY: Joi.string().hex(),
+  STRATEGY_NUM_BLOCKS_BACK: Joi.number().positive().required(),
+  JWT_ACCESS_TOKEN_EXPIRES_IN: Joi.string().required(), // TODO: implement validation of this flexible format
+  JWT_REFRESH_TOKEN_EXPIRES_IN: Joi.string().required(), // TODO: implement validation of this flexible format
+  JWT_ACCESS_TOKEN_NAME: Joi.string().required(),
+  JWT_REFRESH_TOKEN_NAME: Joi.string().required(),
+
+  UNIVERSAL_RESOLVER_URL: Joi.string().uri().required(),
+
+  SENTRY_DNS: Joi.string().allow(''),
+  SENTRY_ENV: Joi.string().allow(''),
+  SENTRY_RELEASE: Joi.string().allow(''),
+
+  STATUS_LIST_DOMAIN: Joi.string().uri().required(),
+});

--- a/src/env-vars-validation-schema.ts
+++ b/src/env-vars-validation-schema.ts
@@ -35,7 +35,7 @@ export const envVarsValidationSchema = Joi.object({
   DB_USERNAME: Joi.string().required(),
   DB_PASSWORD: Joi.string().required(),
 
-  REDIS_PASSWORD: Joi.string().required(),
+  REDIS_PASSWORD: Joi.string().optional(),
   REDIS_PORT: Joi.number().port().required(),
   REDIS_HOST: Joi.string().hostname().required(),
 


### PR DESCRIPTION
This PR:
- adds validations for env variables so that all required needs to be provided and all are validated formally
- adds a requirement that all env vars accessed with the ConfigService need to be defined in the [validation schema](https://github.com/energywebfoundation/ssi-hub/blob/feat/configuration-validation/src/env-vars-validation-schema.ts), otherwise they are stripped out

TODO:
- [x] solve an issue that causes E2E tests to fail after validations are added. This is caused by the `process.env.DID_REGISTRY_ADDRESS` value overwritten [here](https://github.com/energywebfoundation/ssi-hub/blob/c7191fd73778665fb9b26a36b0b0e1a5af8a2e33/e2e/app.e2e.spec.ts#L39) after validations are executed. With validations enabled ConfigService caches validated values so that this leads to inconsistency between `process.env.DID_REGISTRY_ADDRESS` and `configService.get('DID_REGISTRY_ADDRESS')`