### PR TITLE
fix: fixing ENABLE_AUTH having no effect when set in .env file

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,6 @@
+import { config as loadEnvVars } from 'dotenv';
+loadEnvVars(); // this is required by the Auth decorator depending on process.env.ENABLE_AUTH
+
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';


### PR DESCRIPTION
This PR solves the issue when running SSI HUB locally and enabling authorization with `ENABLE_AUTH` in the `.env` file has no effect.