### PR TITLE
fix: fixing /auth/status endpoint swagger definition 

### DIFF
--- a/src/modules/auth/login.controller.ts
+++ b/src/modules/auth/login.controller.ts
@@ -9,7 +9,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { ApiBody, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { Request, Response } from 'express';
 import ms from 'ms';
 import { LoginGuard } from './login.guard';
@@ -143,6 +143,7 @@ export class LoginController {
   }
 
   @Get('auth/status')
+  @ApiBearerAuth()
   async status(@Req() req: Request) {
     const accessTokenString =
       req.headers['authorization']?.replace('Bearer ', '') ||


### PR DESCRIPTION
This PR fixes /auth/status endpoint is not marked with a padlock icon in the Swagger doc.