### PR TITLE
fix: env vars handling

### DIFF
--- a/src/env-vars-validation-schema.ts
+++ b/src/env-vars-validation-schema.ts
@@ -43,7 +43,7 @@ export const envVarsValidationSchema = Joi.object({
   NATS_ENVIRONMENT_NAME: Joi.string().required(),
 
   ROOT_DOMAIN: Joi.string().domain().required(),
-  CHAIN_ID: Joi.number().positive().required(),
+  CHAIN_ID: Joi.number().integer().positive().required(),
   CHAIN_NAME: Joi.string().required(),
   ENS_URL: Joi.string().uri().required(),
 

--- a/src/modules/assets/assets.service.ts
+++ b/src/modules/assets/assets.service.ts
@@ -157,8 +157,7 @@ export class AssetsService {
       'ASSETS_SYNC_HISTORY_INTERVAL_IN_HOURS'
     );
 
-    const ASSETS_SYNC_ENABLED =
-      this.configService.get<string>('ASSETS_SYNC_ENABLED') === 'true';
+    const ASSETS_SYNC_ENABLED = this.configService.get<boolean>('ASSETS_SYNC_ENABLED');
 
     if (ASSETS_SYNC_ENABLED && ASSETS_SYNC_INTERVAL) {
       const interval = setInterval(

--- a/src/modules/auth/token.service.ts
+++ b/src/modules/auth/token.service.ts
@@ -85,8 +85,7 @@ export class TokenService {
    * A pattern such as the double cookie submit pattern cannot be used because the cache-server does not share an origin with it's clients.
    */
   async handleOriginCheck(req: Request, res: Response, next: NextFunction) {
-    const authEnabled = this.configService.get<string>('ENABLE_AUTH');
-    if (authEnabled === 'false') {
+    if (!this.configService.get<boolean>('ENABLE_AUTH')) {
       return next();
     }
     let token = null;

--- a/src/modules/did/did.processor.ts
+++ b/src/modules/did/did.processor.ts
@@ -50,7 +50,7 @@ export class DIDProcessor {
   public async processDIDDocumentRefresh(job: Job<string>) {
     this.logger.debug(`processing cache refresh for ${job.data}`);
     let doc: DIDDocumentEntity;
-    if (this.configService.get('DID_SYNC_MODE_FULL') === 'true') {
+    if (this.configService.get<boolean>('DID_SYNC_MODE_FULL')) {
       doc = await this.didService.addCachedDocument(job.data, true);
     } else {
       doc = await this.didService.incrementalRefreshCachedDocument(job.data);

--- a/src/modules/did/did.service.ts
+++ b/src/modules/did/did.service.ts
@@ -74,13 +74,13 @@ export class DIDService implements OnModuleInit, OnModuleDestroy {
     );
 
     // Using setInterval so that interval can be set dynamically from config
-    const didDocSyncInterval = this.config.get<string>(
+    const didDocSyncInterval = this.config.get<number>(
       'DIDDOC_SYNC_INTERVAL_IN_HOURS'
     );
     if (didDocSyncInterval && this.config.get<boolean>('DID_SYNC_ENABLED')) {
       const interval = setInterval(
         () => this.syncDocuments(),
-        parseInt(didDocSyncInterval) * 3600000
+        didDocSyncInterval * 3600000
       );
       this.schedulerRegistry.addInterval('DID Document Sync', interval);
     }

--- a/src/modules/did/did.service.ts
+++ b/src/modules/did/did.service.ts
@@ -77,9 +77,7 @@ export class DIDService implements OnModuleInit, OnModuleDestroy {
     const didDocSyncInterval = this.config.get<string>(
       'DIDDOC_SYNC_INTERVAL_IN_HOURS'
     );
-    const DID_SYNC_ENABLED =
-      this.config.get<string>('DID_SYNC_ENABLED') !== 'false';
-    if (didDocSyncInterval && DID_SYNC_ENABLED) {
+    if (didDocSyncInterval && this.config.get<boolean>('DID_SYNC_ENABLED')) {
       const interval = setInterval(
         () => this.syncDocuments(),
         parseInt(didDocSyncInterval) * 3600000

--- a/src/modules/ens/ens.service.ts
+++ b/src/modules/ens/ens.service.ts
@@ -53,7 +53,7 @@ export class EnsService implements OnModuleDestroy {
     this.logger.setContext(EnsService.name);
     utils.Logger.setLogLevel(LogLevel.ERROR);
 
-    const CHAIN_ID = parseInt(this.config.get<string>('CHAIN_ID'));
+    const CHAIN_ID = this.config.get<number>('CHAIN_ID');
     const RESOLVER_V1_ADDRESS = this.config.get<string>('RESOLVER_V1_ADDRESS');
     const RESOLVER_V2_ADDRESS = this.config.get<string>('RESOLVER_V2_ADDRESS');
     this._ROOT_DOMAIN = this.config.get<string>('ROOT_DOMAIN');
@@ -110,7 +110,7 @@ export class EnsService implements OnModuleDestroy {
     });
 
     // Using setInterval so that interval can be set dynamically from config
-    const ensSyncInterval = this.config.get<string>(
+    const ensSyncInterval = this.config.get<number>(
       'ENS_SYNC_INTERVAL_IN_HOURS'
     );
     const ENS_SYNC_ENABLED = this.config.get<boolean>('ENS_SYNC_ENABLED');
@@ -119,7 +119,7 @@ export class EnsService implements OnModuleDestroy {
     if (ensSyncInterval && ENS_SYNC_ENABLED && !isTestEnv) {
       const interval = setInterval(
         () => this.syncENS(),
-        parseInt(ensSyncInterval) * 3600000
+        ensSyncInterval * 3600000
       );
       this.schedulerRegistry.addInterval('ENS Sync', interval);
       this.InitEventListeners();

--- a/src/modules/ens/ens.service.ts
+++ b/src/modules/ens/ens.service.ts
@@ -113,8 +113,7 @@ export class EnsService implements OnModuleDestroy {
     const ensSyncInterval = this.config.get<string>(
       'ENS_SYNC_INTERVAL_IN_HOURS'
     );
-    const ENS_SYNC_ENABLED =
-      this.config.get<string>('ENS_SYNC_ENABLED') !== 'false';
+    const ENS_SYNC_ENABLED = this.config.get<boolean>('ENS_SYNC_ENABLED');
     const isTestEnv = this.config.get<string>('NODE_ENV') === 'test';
 
     if (ensSyncInterval && ENS_SYNC_ENABLED && !isTestEnv) {


### PR DESCRIPTION
After environment variables validation schema values returned by the configuration service are cast to appropriate types, so configuration variables of type boolean or number need to be handled accordingly. This was skipped by mistake when implementing the validation schema.