### PR TITLE
feat(role.dto): add optional schema prop

### DIFF
--- a/docs/api/classes/modules_role_role_dto.FieldsDTO.md
+++ b/docs/api/classes/modules_role_role_dto.FieldsDTO.md
@@ -24,6 +24,7 @@
 - [minValue](modules_role_role_dto.FieldsDTO.md#minvalue)
 - [pattern](modules_role_role_dto.FieldsDTO.md#pattern)
 - [required](modules_role_role_dto.FieldsDTO.md#required)
+- [schema](modules_role_role_dto.FieldsDTO.md#schema)
 
 ### Methods
 
@@ -134,6 +135,15 @@ ___
 #### Implementation of
 
 [Fields](../interfaces/modules_role_role_types.Fields.md).[required](../interfaces/modules_role_role_types.Fields.md#required)
+
+___
+
+### schema
+
+• `Optional` **schema**: `Record`<`string`, `unknown`\>
+
+A JSON Schema definition
+For more information about JSON Schema, see https://json-schema.org/
 
 ## Methods
 

--- a/src/modules/role/role.dto.ts
+++ b/src/modules/role/role.dto.ts
@@ -75,6 +75,15 @@ export class FieldsDTO implements Fields {
   @IsDate()
   @ApiProperty()
   maxDate?: Date;
+
+  /**
+   * A JSON Schema definition
+   * For more information about JSON Schema, see https://json-schema.org/
+   */
+  @IsOptional()
+  @IsDate()
+  @ApiProperty()
+  schema?: Record<string, unknown>;
 }
 
 export class PreconditionsDTO implements EnrolmentPrecondition {


### PR DESCRIPTION
- [x] add prop to dto
- [x] test with role def that has schema

I tested locally that `schema` is returned from a role that issuerField/requestorField with it:
![image](https://user-images.githubusercontent.com/4407464/211874443-9eff7faf-3182-4ccb-b6dc-992f824229b3.png)
