### PR TITLE
Revert "fix: bump chart"

### DIFF
--- a/devops/prod/Chart.yaml
+++ b/devops/prod/Chart.yaml
@@ -13,5 +13,5 @@ appVersion: "1.0"
 
 dependencies:
   - name: iam-cache-server-helm
-    version: 1.2.1
+    version: 1.1.2
     repository: "oci://984870885661.dkr.ecr.us-west-2.amazonaws.com"


### PR DESCRIPTION
This reverts commit d8af92fddd422cdf11cdc7e29ee01d3a1880c9c5.

The objective of this PR is to revert the commit that caused the merge conflict that is preventing the ssi-hub v2.12 release to prod PR from being merged: https://github.com/energywebfoundation/ssi-hub/pull/576