### PR TITLE
fix: instantiate cookiesservice in logincontroller

### DIFF
--- a/docs/api/classes/modules_auth_login_controller.LoginController.md
+++ b/docs/api/classes/modules_auth_login_controller.LoginController.md
@@ -18,14 +18,13 @@
 
 ### constructor
 
-• **new LoginController**(`tokenService`, `cookiesServices`, `configService`, `roleService`)
+• **new LoginController**(`tokenService`, `configService`, `roleService`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `tokenService` | [`TokenService`](modules_auth_token_service.TokenService.md) |
-| `cookiesServices` | [`CookiesServices`](modules_auth_cookies_service.CookiesServices.md) |
 | `configService` | `ConfigService`<`Record`<`string`, `unknown`\>, ``false``\> |
 | `roleService` | [`RoleService`](modules_role_role_service.RoleService.md) |
 

--- a/src/modules/auth/login.controller.ts
+++ b/src/modules/auth/login.controller.ts
@@ -20,9 +20,9 @@ import { RoleService } from '../role/role.service';
 @ApiTags('Auth')
 @Controller({ version: '1' })
 export class LoginController {
+  private cookiesServices = new CookiesServices();
   constructor(
     private tokenService: TokenService,
-    private cookiesServices: CookiesServices,
     private configService: ConfigService,
     private roleService: RoleService
   ) {}


### PR DESCRIPTION
This PR instantiates `CookiesService` in `LoginController` and removes it from constructor params.