### PR TITLE
build(build-deploy.yml): use github.sha

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -166,7 +166,7 @@ jobs:
             PUBLIC_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.configure.outputs.IMAGE_TAG }}
             SENTRY_RELEASE="${{ needs.configure.outputs.IMAGE_TAG }}"
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
-            SENTRY_COMMIT="$GITHUB_SHA"
+            SENTRY_COMMIT="${{ github.sha }}"
 
       - name: ArgoCD login
         uses: clowdhaus/argo-cd-action/@v1.12.1


### PR DESCRIPTION
`{{ github.sha }}` provides correct hash
See https://github.com/energywebfoundation/ssi-hub/actions/runs/4204185001/jobs/7294512989 for test