### PR TITLE
build(sentry-upload): $SENTRY_RELEASE for set-commits

### DIFF
--- a/sentry-upload.sh
+++ b/sentry-upload.sh
@@ -5,6 +5,6 @@ if [ -z "$SENTRY_RELEASE" ]
 else 
   sentry-cli releases new "$SENTRY_RELEASE"
   sentry-cli releases files "$SENTRY_RELEASE" upload-sourcemaps ./dist --url-prefix '~/dist'
-  sentry-cli releases set-commits "$VERSION" --auto
+  sentry-cli releases set-commits "$SENTRY_RELEASE" --auto
   sentry-cli releases finalize "$SENTRY_RELEASE"
 fi


### PR DESCRIPTION
Was using $VERSION before, but I don't think it was working previously.
For example, can see from this `deploy` run from before recent public image changes that $VERSION was not populated: https://github.com/energywebfoundation/ssi-hub/actions/runs/4131584199/jobs/7139370388

> error: Invalid value "" for '<VERSION>': Invalid release version. Slashes and certain whitespace characters are not permitted.

Probably it was copy-pasted from Sentry docs before: https://docs.sentry.io/product/cli/releases/

But I think the correct value is the value that identifies the release