### PR TITLE
build(build-deploy): remove quotes from sentry release

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -155,11 +155,11 @@ jobs:
           file: ./docker/sentry-upload/Dockerfile
           build-args: |
             PUBLIC_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.configure.outputs.IMAGE_TAG }}
-            SENTRY_RELEASE="${{ needs.configure.outputs.IMAGE_TAG }}"
+            SENTRY_RELEASE=${{ needs.configure.outputs.IMAGE_TAG }}
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
             SENTRY_ORG=${{ secrets.SENTRY_ORG }}
             SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }}
-            SENTRY_COMMIT="${{ github.repository }}/${{ github.sha }}"
+            SENTRY_COMMIT=${{ github.repository }}/${{ github.sha }}
 
       - name: ArgoCD login
         uses: clowdhaus/argo-cd-action/@v1.12.1


### PR DESCRIPTION
SENTRY_RELEASE and SENTRY_COMMIT don't need quotes
With quotes, creates quotes around release number (e.g. https://energy-web.sentry.io/releases/%22707651a9-bfa8-4611-a927-92b076a79dbc%22/?project=5651522)