### PR TITLE
chore: adding gp4btc swagger hostnames to allowed origins 

### DIFF
--- a/devops/prod/values.yaml
+++ b/devops/prod/values.yaml
@@ -119,7 +119,7 @@ iam-cache-server-helm:
     JWT_ACCESS_TOKEN_NAME: token
     JWT_REFRESH_TOKEN_NAME: refreshToken
     RESTRICT_CORS_ORIGINS: false
-    ALLOWED_ORIGINS: https://identitycache-gp4btc.energyweb.org,https://switchboard.energyweb.org,https://consortia-stake-ewt.io,https://green.stake-ewt.io,https://greenpool.stake-ewt.io,https://crowdfund4solar.com
+    ALLOWED_ORIGINS: https://identitycache.energyweb.org,https://switchboard.energyweb.org,https://consortia-stake-ewt.io,https://green.stake-ewt.io,https://greenpool.stake-ewt.io,https://crowdfund4solar.com
     STATUS_LIST_DOMAIN: https://identitycache.energyweb.org/v1
     CHAIN_REQUEST_ATTEMPTS: 5
 

--- a/devops/prod/values.yaml
+++ b/devops/prod/values.yaml
@@ -119,7 +119,7 @@ iam-cache-server-helm:
     JWT_ACCESS_TOKEN_NAME: token
     JWT_REFRESH_TOKEN_NAME: refreshToken
     RESTRICT_CORS_ORIGINS: false
-    ALLOWED_ORIGINS: https://switchboard.energyweb.org,https://consortia-stake-ewt.io,https://green.stake-ewt.io,https://greenpool.stake-ewt.io,https://crowdfund4solar.com
+    ALLOWED_ORIGINS: https://identitycache-gp4btc.energyweb.org,https://switchboard.energyweb.org,https://consortia-stake-ewt.io,https://green.stake-ewt.io,https://greenpool.stake-ewt.io,https://crowdfund4solar.com
     STATUS_LIST_DOMAIN: https://identitycache.energyweb.org/v1
     CHAIN_REQUEST_ATTEMPTS: 5
 

--- a/devops/staging/values.yaml
+++ b/devops/staging/values.yaml
@@ -119,7 +119,7 @@ iam-cache-server-helm:
     JWT_ACCESS_TOKEN_EXPIRES_IN: 15m
     JWT_REFRESH_TOKEN_EXPIRES_IN: 1h
     RESTRICT_CORS_ORIGINS: true
-    ALLOWED_ORIGINS: https://identitycache-gp4btc-staging.energyweb.org,https://switchboard-staging.energyweb.org
+    ALLOWED_ORIGINS: https://identitycache-staging.energyweb.org,https://switchboard-staging.energyweb.org
     SIWE_NONCE_EXPIRES_IN: 1m
     JWT_ACCESS_TOKEN_NAME: token
     JWT_REFRESH_TOKEN_NAME: refreshToken

--- a/devops/staging/values.yaml
+++ b/devops/staging/values.yaml
@@ -119,7 +119,7 @@ iam-cache-server-helm:
     JWT_ACCESS_TOKEN_EXPIRES_IN: 15m
     JWT_REFRESH_TOKEN_EXPIRES_IN: 1h
     RESTRICT_CORS_ORIGINS: true
-    ALLOWED_ORIGINS: https://switchboard-staging.energyweb.org
+    ALLOWED_ORIGINS: https://identitycache-gp4btc-staging.energyweb.org,https://switchboard-staging.energyweb.org
     SIWE_NONCE_EXPIRES_IN: 1m
     JWT_ACCESS_TOKEN_NAME: token
     JWT_REFRESH_TOKEN_NAME: refreshToken


### PR DESCRIPTION
This PR fixes the issue with requests sent from the Swagger interface are forbidden server-side 