### PR TITLE
feat: git sha in dockerimage

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -145,6 +145,7 @@ jobs:
           file: ./docker/prod/Dockerfile
           build-args: |
             SENTRY_RELEASE="${{ needs.configure.outputs.IMAGE_TAG }}"
+            GIT_SHA="${{ github.sha }}}"
 
       # Sentry upload is done via a docker build in order to have access to the app files in the image
       - name: create Sentry release

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -1,0 +1,113 @@
+version: '3.9'
+
+services:
+  app:
+    image: ssi-hub
+    build:
+      dockerfile: docker/prod/Dockerfile
+    pull_policy: never
+    command: 'node /app/dist/main.js'
+    depends_on:
+      - postgres
+      - nats
+      - redis
+    ports:
+      - "127.0.0.1:3000:3000"
+    volumes:
+      - ./private.pem:/app/private.pem
+      - ./public.pem:/app/public.pem
+    networks:
+      - main
+    environment:
+      DB_HOST: postgres
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_USERNAME: ${DB_USERNAME}
+      DB_NAME: ${DB_NAME}
+      DB_PORT: ${DB_PORT}
+
+      REDIS_HOST: REDIS
+      REDIS_PORT: 6379
+
+      NATS_CLIENTS_URL: nats:4222
+      NATS_ENVIRONMENT_NAME: ewf-dev
+
+      ROOT_DOMAIN: iam.ewc
+      CHAIN_ID: 73799
+      CHAIN_NAME: volta
+      ENS_URL: https://volta-rpc-vkn5r5zx4ke71f9hcu0c.energyweb.org
+      PUBLIC_RESOLVER_ADDRESS: 0x0a97e07c4Df22e2e31872F20C5BE191D5EFc4680
+      ENS_REGISTRY_ADDRESS: 0xd7CeF70Ba7efc2035256d828d5287e2D285CD1ac
+      DID_REGISTRY_ADDRESS: 0xC15D5A57A8Eb0e1dCBE5D88B8f9a82017e5Cc4AF
+      DOMAIN_NOTIFIER_ADDRESS: 0xeea658026d6CDede4380D3aD030beAC911758A93
+      RESOLVER_V1_ADDRESS: 0xf5EA22c1F799d425356c2aab2004200Ab4490D2b
+      RESOLVER_V2_ADDRESS: 0xcf72f16Ab886776232bea2fcf3689761a0b74EfE
+      CHAIN_REQUEST_ATTEMPTS: 5
+
+      ASSETS_MANAGER_ADDRESS: 0x84d0c7284A869213CB047595d34d6044d9a7E14A
+      ASSETS_SYNC_INTERVAL_IN_HOURS: 10
+      ASSETS_SYNC_HISTORY_INTERVAL_IN_HOURS: 21
+      ASSETS_SYNC_ENABLED: true
+
+      DIDDOC_SYNC_INTERVAL_IN_HOURS: 1
+      DID_SYNC_ENABLED: false
+      ENS_SYNC_INTERVAL_IN_HOURS: 1
+      ENS_SYNC_ENABLED: false
+      DID_SYNC_MODE_FULL: false
+
+      ENABLE_AUTH: true
+      JWT_PRIVATE_KEY_PATH: /app/private.pem
+      JWT_PUBLIC_KEY_PATH: /app/public.pem
+      STRATEGY_CACHE_SERVER: http://localhost:3000/v1/
+      STRATEGY_PRIVATE_KEY: eab5e5ccb983fad7bf7f5cb6b475a7aea95eff0c6523291b0c0ae38b5855459c
+      BLOCKNUM_AUTH_ENABLED: true
+      STRATEGY_NUM_BLOCKS_BACK: 10
+      JWT_ACCESS_TOKEN_EXPIRES_IN: 1d
+      JWT_REFRESH_TOKEN_EXPIRES_IN: 1d
+      SIWE_NONCE_EXPIRES_IN: 1m
+      JWT_ACCESS_TOKEN_NAME: token
+      JWT_REFRESH_TOKEN_NAME: refreshToken
+      RESTRICT_CORS_ORIGINS: false
+      ALLOWED_ORIGINS:
+      UNIVERSAL_RESOLVER_URL: https://dev.uniresolver.io/1:0/identifiers/
+      STATUS_LIST_DOMAIN: http://localhost:3000/v1/
+
+  postgres:
+    image: postgres:12-alpine
+    environment:
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_USERNAME: ${DB_USERNAME}
+      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_PORT: ${DB_PORT}
+    networks:
+      - main
+    volumes:
+      - full-postgres-data:/var/lib/postgresql/data
+#    ports:
+#      - '127.0.0.1:${DB_PORT}:5432'
+  nats:
+    image: synadia/nats-server:nightly
+    volumes:
+      - ./config/:/etc/nats
+    command: '-c /etc/nats/nats.conf'
+    networks:
+      - main
+#    ports:
+#      - '${NATS_CLIENTS_URL}:4222'
+#      - '127.0.0.1:8222:8222'
+#      - '127.0.0.1:9222:9222'
+  redis:
+    image: redis:${REDIS_VERSION}
+    volumes:
+      - full-redis-data:/data
+    environment:
+      - REDIS_REPLICATION_MODE=master
+    networks:
+      - main
+#    ports:
+#      - '127.0.0.1:${REDIS_PORT}:6379'
+networks:
+  main:
+
+volumes:
+  full-postgres-data:
+  full-redis-data:

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -31,6 +31,7 @@ RUN chown -R node:node /app/logs
 
 ARG GIT_SHA
 RUN echo "{\"timestamp\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\", \"gitSha\": \"$GIT_SHA\"}" > /app/build.json
+COPY package.json /app
 
 USER node
 

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -29,6 +29,9 @@ RUN mkdir /app/logs
 
 RUN chown -R node:node /app/logs
 
+ARG GIT_SHA
+RUN echo "{\"timestamp\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\", \"gitSha\": \"$GIT_SHA\"}" > /app/build.json
+
 USER node
 
 ENV NODE_ENV=production

--- a/docs/api/modules.md
+++ b/docs/api/modules.md
@@ -154,3 +154,4 @@
 - [modules/status-list/status-list.module](modules/modules_status_list_status_list_module.md)
 - [modules/status-list/status-list.service](modules/modules_status_list_status_list_service.md)
 - [scripts/migrate](modules/scripts_migrate.md)
+- [setup-swagger.function](modules/setup_swagger_function.md)

--- a/docs/api/modules/setup_swagger_function.md
+++ b/docs/api/modules/setup_swagger_function.md
@@ -1,0 +1,24 @@
+# Module: setup-swagger.function
+
+## Table of contents
+
+### Functions
+
+- [setupSwagger](setup_swagger_function.md#setupswagger)
+
+## Functions
+
+### setupSwagger
+
+▸ **setupSwagger**(`app`, `config`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `app` | `INestApplication` |
+| `config` | `ConfigService`<`Record`<`string`, `unknown`\>, ``false``\> |
+
+#### Returns
+
+`void`

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,6 @@ loadEnvVars(); // this is required by the Auth decorator depending on process.en
 
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
-import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { ValidationPipe, VersioningType } from '@nestjs/common';
 import cookieParser from 'cookie-parser';
 import { ConfigService } from '@nestjs/config';
@@ -12,6 +11,7 @@ import helmet from 'helmet';
 import { SentryService } from './modules/sentry/sentry.service';
 import * as SentryNode from '@sentry/node';
 import { corsConfig } from './common/cors.config';
+import { setupSwagger } from './setup-swagger.function';
 
 // This allows TypeScript to detect our global value and properly assign maps for sentry
 // See more here: https://docs.sentry.io/platforms/node/typescript/
@@ -57,19 +57,7 @@ async function bootstrap() {
   // add compression for the API responses
   app.use(compression());
 
-  const options = new DocumentBuilder()
-    .setTitle('API')
-    .setDescription('Cache Server API documentation')
-    .setVersion('1.0');
-
-  if (process.env.ENABLE_AUTH === 'true') {
-    options.addBearerAuth();
-  }
-
-  const builtOptions = options.build();
-
-  const document = SwaggerModule.createDocument(app, builtOptions);
-  SwaggerModule.setup('api', app, document);
+  setupSwagger(app, configService);
 
   corsConfig(app);
 

--- a/src/setup-swagger.function.ts
+++ b/src/setup-swagger.function.ts
@@ -5,10 +5,13 @@ import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
 export const setupSwagger = (app: INestApplication, config: ConfigService) => {
+  const version = readVersion();
+  const buildInfo = readBuildInfo();
+
   const options = new DocumentBuilder()
     .setTitle('API')
     .setDescription('Cache Server API documentation')
-    .setVersion(readVersion());
+    .setVersion(`${version} (${buildInfo.gitSha}.${buildInfo.timestamp})`);
 
   if (config.get<boolean>('ENABLE_AUTH')) {
     options.addBearerAuth();
@@ -34,4 +37,21 @@ function readVersion(): string {
   }
 
   return pkg.version;
+}
+
+function readBuildInfo():
+  | { timestamp: string; gitSha: string }
+  | Record<string, never> {
+  let buildInfo;
+
+  try {
+    buildInfo = JSON.parse(
+      readFileSync(resolve(__dirname, '../build.json')).toString('utf8')
+    );
+  } catch (err) {
+    console.log(`error reading/parsing build.json: ${err}`);
+    return {};
+  }
+
+  return buildInfo;
 }

--- a/src/setup-swagger.function.ts
+++ b/src/setup-swagger.function.ts
@@ -1,12 +1,14 @@
 import { INestApplication } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
 
 export const setupSwagger = (app: INestApplication, config: ConfigService) => {
   const options = new DocumentBuilder()
     .setTitle('API')
     .setDescription('Cache Server API documentation')
-    .setVersion('1.0');
+    .setVersion(readVersion());
 
   if (config.get<boolean>('ENABLE_AUTH')) {
     options.addBearerAuth();
@@ -18,3 +20,18 @@ export const setupSwagger = (app: INestApplication, config: ConfigService) => {
     SwaggerModule.createDocument(app, options.build())
   );
 };
+
+function readVersion(): string {
+  let pkg;
+
+  try {
+    pkg = JSON.parse(
+      readFileSync(resolve(__dirname, '../package.json')).toString('utf8')
+    );
+  } catch (err) {
+    console.log(`error reading/parsing package.json: ${err}`);
+    return '';
+  }
+
+  return pkg.version;
+}

--- a/src/setup-swagger.function.ts
+++ b/src/setup-swagger.function.ts
@@ -1,0 +1,20 @@
+import { INestApplication } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+
+export const setupSwagger = (app: INestApplication, config: ConfigService) => {
+  const options = new DocumentBuilder()
+    .setTitle('API')
+    .setDescription('Cache Server API documentation')
+    .setVersion('1.0');
+
+  if (config.get<boolean>('ENABLE_AUTH')) {
+    options.addBearerAuth();
+  }
+
+  SwaggerModule.setup(
+    'api',
+    app,
+    SwaggerModule.createDocument(app, options.build())
+  );
+};


### PR DESCRIPTION
This PR adds the application build version displayed by the Swagger document with:
- injecting GIT_SHA arg into the docker image when built in CI
- storing build info in the `build.json` file inside the docker image
- adding the `package.json` file to the docker image
- getting the version from the `package.json` file
- parsing `build.json` and displaying git sha and build timestamp next to the version in Swagger
- handling cases of not present or non-parseable files