### PR TITLE
fix(CD): fixing non-parseable `build.json` file

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -145,7 +145,7 @@ jobs:
           file: ./docker/prod/Dockerfile
           build-args: |
             SENTRY_RELEASE="${{ needs.configure.outputs.IMAGE_TAG }}"
-            GIT_SHA="${{ github.sha }}"
+            GIT_SHA=${{ github.sha }}
 
       # Sentry upload is done via a docker build in order to have access to the app files in the image
       - name: create Sentry release


### PR DESCRIPTION
Looks like quotation marks break json created in the Dokerfile: https://github.com/energywebfoundation/ssi-hub/blob/340f022c44b6178b547fb650b545cd378e1818d5/docker/prod/Dockerfile#L33