### PR TITLE
chore: allow CORS from origin without top level domain

### DIFF
--- a/src/common/cors.config.ts
+++ b/src/common/cors.config.ts
@@ -6,7 +6,7 @@ export function corsConfig(app: INestApplication) {
   const configService = app.get(ConfigService);
   const allowedOrigins = configService.get('ALLOWED_ORIGINS').split(',');
   for (const origin of allowedOrigins) {
-    if (!isURL(origin)) {
+    if (!isURL(origin, { require_tld: false })) {
       throw new Error(`Origin ${origin} is not a valid URL`);
     }
   }


### PR DESCRIPTION
This should simplify local development by setting `ALLOWED_CORS_ORIGIN` to `http://localhost:4200`. Currently this url is not allowed, because `isUrl` validator [here](https://github.com/energywebfoundation/ssi-hub/blob/c2b949ee46532ea59665d694f134df23b1721051/src/common/cors.config.ts#L9) by default requires top level domain