### PR TITLE
fix(logger.service): disable digits redactor

### DIFF
--- a/docs/api/classes/modules_assets_assets_service.AssetsService.md
+++ b/docs/api/classes/modules_assets_assets_service.AssetsService.md
@@ -65,7 +65,7 @@ ___
 | :------ | :------ |
 | `assetId` | `string` |
 | `«destructured»` | `Object` |
-| › `order` | ``"ASC"`` \| ``"DESC"`` |
+| › `order` | ``"DESC"`` \| ``"ASC"`` |
 | › `skip` | `number` |
 | › `take` | `number` |
 | › `type` | [`AssetHistoryEventType`](../enums/modules_assets_assets_event.AssetHistoryEventType.md) |

--- a/src/modules/logger/logger.service.ts
+++ b/src/modules/logger/logger.service.ts
@@ -26,6 +26,11 @@ export class Logger extends NestLogger implements LoggerService {
   ) {
     super();
     this.redactor = new SyncRedactor({
+      builtInRedactors: {
+        digits: {
+          enabled: false,
+        },
+      },
       customRedactors: {
         before: [
           {


### PR DESCRIPTION
With digits redactor, the logs looked like:

debug [DIDService] : 2024-11-21T22:32:25.999Z - Fetched 0 DID events from interval [DIGITS, DIGITS]