### PR TITLE
feat(deps): update passport-did-auth to 2.1.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "pako": "^2.0.4",
         "parse-duration": "^1.0.2",
         "passport": "^0.6.0",
-        "passport-did-auth": "^2.0.1-alpha.3",
+        "passport-did-auth": "^2.1.0-alpha.1",
         "passport-jwt": "^4.0.0",
         "pg": "^8.5.1",
         "redact-pii": "^3.2.3",
@@ -1365,9 +1365,9 @@
       }
     },
     "node_modules/@energyweb/credential-governance": {
-      "version": "2.2.1-alpha.319.0",
-      "resolved": "https://registry.npmjs.org/@energyweb/credential-governance/-/credential-governance-2.2.1-alpha.319.0.tgz",
-      "integrity": "sha512-bex5H80pwq8wdBiXqIwEzYae2IxsErU4G2vChwXF19N8UoA9ZsNfRdKIGVtsgwsQ19o+x3bMfAtJCzHEQlY3JA==",
+      "version": "2.2.1-alpha.321.0",
+      "resolved": "https://registry.npmjs.org/@energyweb/credential-governance/-/credential-governance-2.2.1-alpha.321.0.tgz",
+      "integrity": "sha512-x+MUUF8gQ+TpEia/XLw3eN8P4ca1WktFHfLLnU4FWyIoX3qM8frUCu5kg56SDORDdkI2tm1zOmu+zme0vEn4Sg==",
       "dependencies": {
         "@cjs-exporter/p-map": "5.5.0",
         "@ew-did-registry/credentials-interface": "^0.8.1-alpha.1122.0",
@@ -1389,11 +1389,11 @@
       }
     },
     "node_modules/@energyweb/onchain-claims": {
-      "version": "2.2.1-alpha.319.0",
-      "resolved": "https://registry.npmjs.org/@energyweb/onchain-claims/-/onchain-claims-2.2.1-alpha.319.0.tgz",
-      "integrity": "sha512-GplaqwtefcaT21wnu2FM3XUkdfsN2qUQGEzKz/9v4TGgv/plnYQvhboC3aUQEd6MB610+trEKNxYHgst9Ooojg==",
+      "version": "2.2.1-alpha.321.0",
+      "resolved": "https://registry.npmjs.org/@energyweb/onchain-claims/-/onchain-claims-2.2.1-alpha.321.0.tgz",
+      "integrity": "sha512-9YueWHPUE+KPVYlsnRmsummVmok/amSfMitjUUvBWuRHnZVc5SfBG5Q2iI3sc+jtpd8MEDxwLe6dCpQiOU++zQ==",
       "dependencies": {
-        "@energyweb/credential-governance": "2.2.1-alpha.319.0",
+        "@energyweb/credential-governance": "2.2.1-alpha.321.0",
         "@ew-did-registry/did": "^0.8.1-alpha.1122.0",
         "@ew-did-registry/did-ethr-resolver": "^0.8.1-alpha.1122.0",
         "ethers": "^5.7.2"
@@ -1409,12 +1409,12 @@
       }
     },
     "node_modules/@energyweb/vc-verification": {
-      "version": "2.2.1-alpha.319.0",
-      "resolved": "https://registry.npmjs.org/@energyweb/vc-verification/-/vc-verification-2.2.1-alpha.319.0.tgz",
-      "integrity": "sha512-FLMFEbI4iqcSMHPNv66qsctLgbVey/AmoWAST/rNsdnIh5uAw+cQ6a7xJkYiswIY6JVzxvpaZpUfFdKvi4jzVQ==",
+      "version": "2.2.1-alpha.321.0",
+      "resolved": "https://registry.npmjs.org/@energyweb/vc-verification/-/vc-verification-2.2.1-alpha.321.0.tgz",
+      "integrity": "sha512-imKykb4skjeFyYeSxWIbwU/gVIAJLU0n2+rkuehhXfGIj1NCftUWakF87rFxPsvsmfKv+fyoQUEMAonjf8wwvg==",
       "dependencies": {
-        "@energyweb/credential-governance": "2.2.1-alpha.319.0",
-        "@energyweb/onchain-claims": "2.2.1-alpha.319.0",
+        "@energyweb/credential-governance": "2.2.1-alpha.321.0",
+        "@energyweb/onchain-claims": "2.2.1-alpha.321.0",
         "@ew-did-registry/claims": "^0.8.1-alpha.1122.0",
         "@ew-did-registry/credentials-interface": "^0.8.1-alpha.1122.0",
         "@ew-did-registry/did-ethr-resolver": "^0.8.1-alpha.1122.0",
@@ -28583,13 +28583,13 @@
       }
     },
     "node_modules/passport-did-auth": {
-      "version": "2.0.1-alpha.3",
-      "resolved": "https://registry.npmjs.org/passport-did-auth/-/passport-did-auth-2.0.1-alpha.3.tgz",
-      "integrity": "sha512-wnqQ0AiOU/y9UqjYloUfoUuhrGKtkMmYqbQ2k21YVVy2me8UjBzz3LqpwPl5S4OxMvvJeRY+vcmtqS3fsi5jrQ==",
+      "version": "2.1.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/passport-did-auth/-/passport-did-auth-2.1.0-alpha.1.tgz",
+      "integrity": "sha512-4rIBchVSmNK1MmfVexNbF7VMHZAlih8Ty21i5yL2F6nrIpae5+7U7BnNXjRYytmLhD5GJn6GNbWLR22lpoEK9A==",
       "dependencies": {
-        "@energyweb/credential-governance": "^2.2.1-alpha.319.0",
-        "@energyweb/onchain-claims": "^2.2.1-alpha.319.0",
-        "@energyweb/vc-verification": "^2.2.1-alpha.319.0",
+        "@energyweb/credential-governance": "2.2.1-alpha.321.0",
+        "@energyweb/onchain-claims": "2.2.1-alpha.321.0",
+        "@energyweb/vc-verification": "2.2.1-alpha.321.0",
         "@ensdomains/ens-contracts": "^0.0.21",
         "@ew-did-registry/claims": "0.8.1-alpha.1140.0",
         "@ew-did-registry/did": "0.8.1-alpha.1140.0",
@@ -35562,9 +35562,9 @@
       }
     },
     "@energyweb/credential-governance": {
-      "version": "2.2.1-alpha.319.0",
-      "resolved": "https://registry.npmjs.org/@energyweb/credential-governance/-/credential-governance-2.2.1-alpha.319.0.tgz",
-      "integrity": "sha512-bex5H80pwq8wdBiXqIwEzYae2IxsErU4G2vChwXF19N8UoA9ZsNfRdKIGVtsgwsQ19o+x3bMfAtJCzHEQlY3JA==",
+      "version": "2.2.1-alpha.321.0",
+      "resolved": "https://registry.npmjs.org/@energyweb/credential-governance/-/credential-governance-2.2.1-alpha.321.0.tgz",
+      "integrity": "sha512-x+MUUF8gQ+TpEia/XLw3eN8P4ca1WktFHfLLnU4FWyIoX3qM8frUCu5kg56SDORDdkI2tm1zOmu+zme0vEn4Sg==",
       "requires": {
         "@cjs-exporter/p-map": "5.5.0",
         "@ew-did-registry/credentials-interface": "^0.8.1-alpha.1122.0",
@@ -35579,11 +35579,11 @@
       "dev": true
     },
     "@energyweb/onchain-claims": {
-      "version": "2.2.1-alpha.319.0",
-      "resolved": "https://registry.npmjs.org/@energyweb/onchain-claims/-/onchain-claims-2.2.1-alpha.319.0.tgz",
-      "integrity": "sha512-GplaqwtefcaT21wnu2FM3XUkdfsN2qUQGEzKz/9v4TGgv/plnYQvhboC3aUQEd6MB610+trEKNxYHgst9Ooojg==",
+      "version": "2.2.1-alpha.321.0",
+      "resolved": "https://registry.npmjs.org/@energyweb/onchain-claims/-/onchain-claims-2.2.1-alpha.321.0.tgz",
+      "integrity": "sha512-9YueWHPUE+KPVYlsnRmsummVmok/amSfMitjUUvBWuRHnZVc5SfBG5Q2iI3sc+jtpd8MEDxwLe6dCpQiOU++zQ==",
       "requires": {
-        "@energyweb/credential-governance": "2.2.1-alpha.319.0",
+        "@energyweb/credential-governance": "2.2.1-alpha.321.0",
         "@ew-did-registry/did": "^0.8.1-alpha.1122.0",
         "@ew-did-registry/did-ethr-resolver": "^0.8.1-alpha.1122.0",
         "ethers": "^5.7.2"
@@ -35596,12 +35596,12 @@
       "dev": true
     },
     "@energyweb/vc-verification": {
-      "version": "2.2.1-alpha.319.0",
-      "resolved": "https://registry.npmjs.org/@energyweb/vc-verification/-/vc-verification-2.2.1-alpha.319.0.tgz",
-      "integrity": "sha512-FLMFEbI4iqcSMHPNv66qsctLgbVey/AmoWAST/rNsdnIh5uAw+cQ6a7xJkYiswIY6JVzxvpaZpUfFdKvi4jzVQ==",
+      "version": "2.2.1-alpha.321.0",
+      "resolved": "https://registry.npmjs.org/@energyweb/vc-verification/-/vc-verification-2.2.1-alpha.321.0.tgz",
+      "integrity": "sha512-imKykb4skjeFyYeSxWIbwU/gVIAJLU0n2+rkuehhXfGIj1NCftUWakF87rFxPsvsmfKv+fyoQUEMAonjf8wwvg==",
       "requires": {
-        "@energyweb/credential-governance": "2.2.1-alpha.319.0",
-        "@energyweb/onchain-claims": "2.2.1-alpha.319.0",
+        "@energyweb/credential-governance": "2.2.1-alpha.321.0",
+        "@energyweb/onchain-claims": "2.2.1-alpha.321.0",
         "@ew-did-registry/claims": "^0.8.1-alpha.1122.0",
         "@ew-did-registry/credentials-interface": "^0.8.1-alpha.1122.0",
         "@ew-did-registry/did-ethr-resolver": "^0.8.1-alpha.1122.0",
@@ -56766,13 +56766,13 @@
       }
     },
     "passport-did-auth": {
-      "version": "2.0.1-alpha.3",
-      "resolved": "https://registry.npmjs.org/passport-did-auth/-/passport-did-auth-2.0.1-alpha.3.tgz",
-      "integrity": "sha512-wnqQ0AiOU/y9UqjYloUfoUuhrGKtkMmYqbQ2k21YVVy2me8UjBzz3LqpwPl5S4OxMvvJeRY+vcmtqS3fsi5jrQ==",
+      "version": "2.1.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/passport-did-auth/-/passport-did-auth-2.1.0-alpha.1.tgz",
+      "integrity": "sha512-4rIBchVSmNK1MmfVexNbF7VMHZAlih8Ty21i5yL2F6nrIpae5+7U7BnNXjRYytmLhD5GJn6GNbWLR22lpoEK9A==",
       "requires": {
-        "@energyweb/credential-governance": "^2.2.1-alpha.319.0",
-        "@energyweb/onchain-claims": "^2.2.1-alpha.319.0",
-        "@energyweb/vc-verification": "^2.2.1-alpha.319.0",
+        "@energyweb/credential-governance": "2.2.1-alpha.321.0",
+        "@energyweb/onchain-claims": "2.2.1-alpha.321.0",
+        "@energyweb/vc-verification": "2.2.1-alpha.321.0",
         "@ensdomains/ens-contracts": "^0.0.21",
         "@ew-did-registry/claims": "0.8.1-alpha.1140.0",
         "@ew-did-registry/did": "0.8.1-alpha.1140.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "pako": "^2.0.4",
     "parse-duration": "^1.0.2",
     "passport": "^0.6.0",
-    "passport-did-auth": "^2.0.1-alpha.3",
+    "passport-did-auth": "^2.1.0-alpha.1",
     "passport-jwt": "^4.0.0",
     "pg": "^8.5.1",
     "redact-pii": "^3.2.3",


### PR DESCRIPTION
The new version has an updated vc-verification package that includes a timeout when resolving IPFS data. This is useful in the data where IPFS data can't be resolved. We recently observed this for Infura hosted data that was added via the public gateway.