### PR TITLE
Feat make cluster pinning configurable

### DIFF
--- a/docs/api/classes/modules_ipfs_pin_processor.PinProcessor.md
+++ b/docs/api/classes/modules_ipfs_pin_processor.PinProcessor.md
@@ -34,13 +34,13 @@
 
 ### OnQueueWaiting
 
-▸ **OnQueueWaiting**(`job`): `Promise`<`void`\>
+▸ **OnQueueWaiting**(`jobId`): `Promise`<`void`\>
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `job` | `Job`<`any`\> |
+| `jobId` | `number` |
 
 #### Returns
 
@@ -72,7 +72,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `job` | `Job`<`any`\> |
+| `job` | `Job`<[`PinClaimData`](../modules/modules_ipfs_ipfs_types.md#pinclaimdata)\> |
 | `err` | `Error` |
 
 #### Returns
@@ -89,7 +89,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `job` | `Job`<`any`\> |
+| `job` | `Job`<[`PinClaimData`](../modules/modules_ipfs_ipfs_types.md#pinclaimdata)\> |
 
 #### Returns
 

--- a/src/env-vars-validation-schema.ts
+++ b/src/env-vars-validation-schema.ts
@@ -95,6 +95,7 @@ export const envVarsValidationSchema = Joi.object({
   IPFS_CLIENT_PORT: Joi.number().port(),
   IPFS_CLIENT_PROJECT_ID: Joi.string(),
   IPFS_CLIENT_PROJECT_SECRET: Joi.string(),
+  IPFS_CLUSTER_PINNING_ENABLED: Joi.boolean().optional().default(false),
   IPFS_CLUSTER_ROOT: Joi.string().required(),
   IPFS_CLUSTER_USER: Joi.string(),
   IPFS_CLUSTER_PASSWORD: Joi.string(),

--- a/src/modules/did/did.processor.ts
+++ b/src/modules/did/did.processor.ts
@@ -81,8 +81,14 @@ export class DIDProcessor {
   private async addPinJobs(doc: DIDDocumentEntity) {
     // Cluster pinning needs to be explictly set to true
     if (!this.configService.get<boolean>('IPFS_CLUSTER_PINNING_ENABLED')) {
+      this.logger.debug(
+        `IPFS cluster pinning disabled. Skipping for ${doc?.id}`
+      );
       return;
     }
+    this.logger.debug(
+      `IPFS cluster pinning enabled. Pinning IPFS data for ${doc?.id}`
+    );
     await Promise.all(
       doc.service.map(({ serviceEndpoint }) => {
         this.pinQueue.add(PIN_CLAIM_JOB_NAME, {

--- a/src/modules/did/did.processor.ts
+++ b/src/modules/did/did.processor.ts
@@ -64,14 +64,7 @@ export class DIDProcessor {
   @Process(ADD_DID_DOC_JOB_NAME)
   public async processDIDDocumentAddition(job: Job<string>) {
     const doc = await this.didService.addCachedDocument(job.data);
-
-    await Promise.all(
-      doc.service.map(({ serviceEndpoint }) => {
-        this.pinQueue.add(PIN_CLAIM_JOB_NAME, {
-          cid: serviceEndpoint,
-        });
-      })
-    );
+    await this.addPinJobs(doc);
   }
 
   @Process(UPDATE_DID_DOC_JOB_NAME)
@@ -82,7 +75,10 @@ export class DIDProcessor {
     } else {
       doc = await this.didService.incrementalRefreshCachedDocument(job.data);
     }
+    await this.addPinJobs(doc);
+  }
 
+  private async addPinJobs(doc: DIDDocumentEntity) {
     await Promise.all(
       doc.service.map(({ serviceEndpoint }) => {
         this.pinQueue.add(PIN_CLAIM_JOB_NAME, {

--- a/src/modules/did/did.processor.ts
+++ b/src/modules/did/did.processor.ts
@@ -79,6 +79,10 @@ export class DIDProcessor {
   }
 
   private async addPinJobs(doc: DIDDocumentEntity) {
+    // Cluster pinning needs to be explictly set to true
+    if (!this.configService.get<boolean>('IPFS_CLUSTER_PINNING_ENABLED')) {
+      return;
+    }
     await Promise.all(
       doc.service.map(({ serviceEndpoint }) => {
         this.pinQueue.add(PIN_CLAIM_JOB_NAME, {


### PR DESCRIPTION
Adds configuration to disable IPFS cluster pinning. As EW isn't hosting the IPFS cluster, the pinning always fails which makes logs much harder to read.