### PR TITLE
chore(staging values): update app version with ipfs timeout fix

### DIFF
--- a/devops/staging/values.yaml
+++ b/devops/staging/values.yaml
@@ -12,7 +12,7 @@ iam-cache-server-helm:
 
   image:
     repository: "ghcr.io/energywebfoundation/ssi-hub"
-    tag: v2.13.0
+    tag: 126ac01c-81c5-48df-8ef9-0dd8154a957b
     pullPolicy: IfNotPresent
 
   imagePullSecrets: [ ]


### PR DESCRIPTION
This version allows login despire failed queries to IPFS. The version tag can be verified here: https://github.com/energywebfoundation/ssi-hub/pkgs/container/ssi-hub/versions
Will update with proper released version once the fix is published. 